### PR TITLE
Add default functionality to randomly generate a bonobo image when no users given

### DIFF
--- a/main.py
+++ b/main.py
@@ -148,6 +148,12 @@ class BonoboCog(commands.Cog):
 
     @commands.command(aliases=["bonobot"])
     async def bonobo(self, ctx, users: commands.Greedy[DiscordMonke]):
+        if len(users) == 0:
+            users = [
+                random.choice(ctx.guild.members)
+                for _ in range(random.sample(self.templates, 1)[0].faces)
+            ]
+
         available_templates = list(
             filter(lambda t: t.faces == len(users), self.templates)
         )


### PR DESCRIPTION
Now the command `!bonobo` on its own without any users will pick a random template and fill it in with random users from the server

![image](https://user-images.githubusercontent.com/18558130/113362038-6605fa80-931b-11eb-8301-6d30aaf92c87.png)

![image](https://user-images.githubusercontent.com/18558130/113362044-6b634500-931b-11eb-86ae-4c18cdcd2ce8.png)
